### PR TITLE
Use generics for string arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go_true = "0.1.1"
 To create an account, create a new client and execute the `sign_up` function with email and password:
 
 ```rust
-use go_true::Client;
+use go_true::{Client, EmailOrPhone};
 
 #[tokio::main]
 async fn main() {
@@ -28,7 +28,7 @@ async fn main() {
     let email = "email@example.com".to_string();
     let password = "Abcd1234!";
 
-    let session = client.sign_up(&email, password).await;
+    let session = client.sign_up(EmailOrPhone::Email(email), password).await;
 
     println!("{:?}", session);
 }

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 [![Crate](https://img.shields.io/crates/v/go_true.svg)](https://crates.io/crates/go_true)
 [![License: MIT](https://img.shields.io/crates/l/go_true.svg)](#license)
 
-This is a [GoTrue](https://github.com/supabase/gotrue) client implementation in rust. The library is currently under development. Most of the features are already built in, but there are still some changes to be made and everything still needs to be documented. 
+This is a [GoTrue](https://github.com/supabase/gotrue) client implementation in rust. The library is currently under development. Most of the features are already built in, but there are still some changes to be made and everything still needs to be documented.
 
 ## Usage
+
 Add the following line to your `Cargo.toml`:
 
 ```toml
@@ -22,13 +23,12 @@ use go_true::Client;
 
 #[tokio::main]
 async fn main() {
-    let url = "http://localhost:9998".to_string();
-    let mut client = Client::new(url);
+    let mut client = Client::new("http://localhost:9998");
 
     let email = "email@example.com".to_string();
-    let password = "Abcd1234!".to_string();
+    let password = "Abcd1234!";
 
-    let session = client.sign_up(&email, &password).await;
+    let session = client.sign_up(&email, password).await;
 
     println!("{:?}", session);
 }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   gotrue: # Signup enabled, autoconfirm off
-    image: supabase/gotrue:latest
+    image: supabase/gotrue:v2.132.3
     ports:
       - "9999:9999"
     environment:
@@ -42,7 +42,7 @@ services:
       - db
     restart: on-failure
   autoconfirm: # Signup enabled, autoconfirm on
-    image: supabase/gotrue:latest
+    image: supabase/gotrue:v2.132.3
     ports:
       - "9998:9998"
     environment:
@@ -71,7 +71,7 @@ services:
       - db
     restart: on-failure
   disabled: # Signup disabled
-    image: supabase/gotrue:latest
+    image: supabase/gotrue:v2.132.3
     ports:
       - "9997:9997"
     environment:

--- a/src/api.rs
+++ b/src/api.rs
@@ -389,7 +389,7 @@ impl Api {
     /// # Example
     ///
     /// ```
-    /// use go_true::{Api, EmailOrPhone};
+    /// use go_true::{Api, EmailOrPhone, UserAttributes};
     /// use serde_json::json;
     ///
     /// #[tokio::main]
@@ -405,12 +405,12 @@ impl Api {
     ///
     ///     let new_email = "otheremail@example.com";
     ///     let attributes = UserAttributes {
-    ///         email: new_email.clone(),
+    ///         email: new_email.to_string(),
     ///         password: "Abcd12345!".to_string(),
     ///         data: json!({ "test": "test" }),
     ///     };
     ///
-    ///     let updatedUser = client.update_user(attributes, &session.access_token).await?;
+    ///     let updated_user = client.update_user(attributes, &session.access_token).await?;
     ///     Ok(())
     /// }
     /// ```
@@ -582,7 +582,7 @@ impl Api {
     ///     let mut client = Api::new("http://localhost:9998");
     ///
     ///     let user = AdminUserAttributes {
-    ///         email: "createemail@example.com",
+    ///         email: "createemail@example.com".to_string(),
     ///         password: Some(String::from("Abcd1234!")),
     ///         data: None,
     ///         email_confirmed: None,
@@ -683,7 +683,7 @@ impl Api {
     ///     let mut client = Api::new("http://localhost:9998");
     ///
     ///     let user = AdminUserAttributes {
-    ///         email: "delete@example.com",
+    ///         email: "delete@example.com".to_string(),
     ///         password: Some(String::from("Abcd1234!")),
     ///         data: None,
     ///         email_confirmed: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,9 +19,9 @@ impl Client {
     /// ```
     /// use go_true::Client;
     ///
-    /// let client = Client::new("http://your.gotrue.endpoint".to_string());
+    /// let client = Client::new("http://your.gotrue.endpoint");
     /// ```
-    pub fn new(url: String) -> Client {
+    pub fn new(url: impl Into<String>) -> Client {
         Client {
             current_session: None,
             api: Api::new(url),
@@ -36,22 +36,22 @@ impl Client {
     /// use go_true::{Client, EmailOrPhone};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
     ///     let email = "some_email".to_string();
-    ///     let password = "some_password".to_string();
+    ///     let password = "some_password";
     ///     let res = client
-    ///         .sign_up(EmailOrPhone::Email(email), &password)
+    ///         .sign_up(EmailOrPhone::Email(email), password)
     ///         .await?;
     ///     Ok(())
     /// }
     pub async fn sign_up(
         &mut self,
         email_or_phone: EmailOrPhone,
-        password: &String,
+        password: impl AsRef<str>,
     ) -> Result<Session, Error> {
         self.current_session = None;
-        let result = self.api.sign_up(email_or_phone, &password).await;
+        let result = self.api.sign_up(email_or_phone, password).await;
 
         match result {
             Ok(session) => {
@@ -75,22 +75,22 @@ impl Client {
     /// use go_true::{Client, EmailOrPhone};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
     ///     let email = "some_email".to_string();
-    ///     let password = "some_password".to_string();
+    ///     let password = "some_password";
     ///     let res = client
-    ///         .sign_in(EmailOrPhone::Email(email), &password)
+    ///         .sign_in(EmailOrPhone::Email(email), password)
     ///         .await?;
     ///     Ok(())
     /// }
     pub async fn sign_in(
         &mut self,
         email_or_phone: EmailOrPhone,
-        password: &String,
+        password: impl AsRef<str>,
     ) -> Result<Session, Error> {
         self.current_session = None;
-        let result = self.api.sign_in(email_or_phone, &password).await;
+        let result = self.api.sign_in(email_or_phone, password).await;
 
         match result {
             Ok(session) => {
@@ -114,8 +114,8 @@ impl Client {
     /// use go_true::{Client, EmailOrPhone};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
     ///     let email = "some_email".to_string();
     ///
     ///     let res = client
@@ -164,8 +164,8 @@ impl Client {
     /// use go_true::{Client};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
     ///
     ///     // Sign in first
     ///
@@ -192,15 +192,15 @@ impl Client {
     /// use go_true::{Client};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
-    ///     let email = "some_email".to_string()
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
+    ///     let email = "some_email";
     ///
-    ///     let res = client.reset_password_for_email(&email).await?;
+    ///     let res = client.reset_password_for_email(email).await?;
     ///     Ok(())
     /// }
-    pub async fn reset_password_for_email(&self, email: &str) -> Result<bool, Error> {
-        let result = self.api.reset_password_for_email(&email).await;
+    pub async fn reset_password_for_email(&self, email: impl AsRef<str>) -> Result<bool, Error> {
+        let result = self.api.reset_password_for_email(email).await;
 
         match result {
             Ok(_) => return Ok(true),
@@ -235,8 +235,8 @@ impl Client {
     /// use go_true::{Client};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
     ///
     ///     // sign in first
     ///
@@ -271,15 +271,15 @@ impl Client {
     /// use go_true::{Client};
     ///
     /// #[tokio::main]
-    ///     async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint".to_string());
-    ///     let token = "refresh_token".to_string();
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let client = Client::new("http://your.gotrue.endpoint");
+    ///     let token = "refresh_token";
     ///
     ///     let session = client.set_session(token).await?:
     ///     Ok(())
     /// }
-    pub async fn set_session(&mut self, refresh_token: &str) -> Result<Session, Error> {
-        if refresh_token.len() < 1 {
+    pub async fn set_session(&mut self, refresh_token: impl AsRef<str>) -> Result<Session, Error> {
+        if refresh_token.as_ref().len() < 1 {
             return Err(Error::NotAuthenticated);
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,7 +37,7 @@ impl Client {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint");
+    ///     let mut client = Client::new("http://your.gotrue.endpoint");
     ///     let email = "some_email".to_string();
     ///     let password = "some_password";
     ///     let res = client
@@ -76,7 +76,7 @@ impl Client {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint");
+    ///     let mut client = Client::new("http://your.gotrue.endpoint");
     ///     let email = "some_email".to_string();
     ///     let password = "some_password";
     ///     let res = client
@@ -236,11 +236,11 @@ impl Client {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint");
+    ///     let mut client = Client::new("http://your.gotrue.endpoint");
     ///
     ///     // sign in first
     ///
-    ///     client.refresh_session().await?:
+    ///     client.refresh_session().await?;
     ///     Ok(())
     /// }
     pub async fn refresh_session(&mut self) -> Result<Session, Error> {
@@ -272,10 +272,10 @@ impl Client {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = Client::new("http://your.gotrue.endpoint");
+    ///     let mut client = Client::new("http://your.gotrue.endpoint");
     ///     let token = "refresh_token";
     ///
-    ///     let session = client.set_session(token).await?:
+    ///     let session = client.set_session(token).await?;
     ///     Ok(())
     /// }
     pub async fn set_session(&mut self, refresh_token: impl AsRef<str>) -> Result<Session, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,13 +18,12 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let url = "http://localhost:9998".to_string();
-//!     let mut client = Client::new(url);
+//!     let mut client = Client::new("http://localhost:9998");
 //!
 //!     let email = "email@example.com".to_string();
-//!     let password = "Abcd1234!".to_string();
+//!     let password = "Abcd1234!";
 //!
-//!     let session = client.sign_up(EmailOrPhone::Email(email), &password).await;
+//!     let session = client.sign_up(EmailOrPhone::Email(email), password).await;
 //!
 //!     println!("{:?}", session);
 //! }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -21,7 +21,7 @@ struct AdminUserAttributes {
 }
 
 fn get_api_client() -> Api {
-    let api: Api = Api::new(String::from("http://localhost:9998"));
+    let api: Api = Api::new("http://localhost:9998");
 
     return api;
 }
@@ -33,7 +33,7 @@ fn get_service_api_client() -> Api {
     claims.insert("role", "supabase_admin");
 
     let token_str = claims.sign_with_key(&key).unwrap();
-    let api: Api = Api::new(String::from("http://localhost:9998"))
+    let api: Api = Api::new("http://localhost:9998")
         .insert_header("Authorization", format!("Bearer {token_str}"));
 
     return api;
@@ -53,11 +53,11 @@ fn get_random_email() -> String {
 #[tokio::test]
 async fn it_signs_up_with_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
     let res = api
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     assert_eq!(res.user.email, email);
@@ -68,13 +68,13 @@ async fn it_signs_up_with_email() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_signs_in_with_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = api
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     assert_eq!(res.user.email, email);
@@ -84,10 +84,10 @@ async fn it_signs_in_with_email() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_send_magic_link_with_valid_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = api
         .send_otp(EmailOrPhone::Email(email.clone()), None)
@@ -115,13 +115,13 @@ async fn it_does_not_send_magic_link_with_invalid_email() -> Result<(), Box<dyn 
 #[tokio::test]
 async fn it_should_log_out() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = api
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     assert_eq!(res.user.email, email);
@@ -136,18 +136,18 @@ async fn it_should_log_out() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_return_error_if_token_is_invalid() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = api
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     assert_eq!(res.user.email, email);
 
-    let success = api.sign_out(&"invalid-token".to_string()).await;
+    let success = api.sign_out("invalid-token").await;
 
     match success {
         Ok(_) => panic!("Should not work"),
@@ -159,10 +159,10 @@ async fn it_should_return_error_if_token_is_invalid() -> Result<(), Box<dyn Erro
 #[tokio::test]
 async fn it_should_send_password_recovery_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     let success = api.reset_password_for_email(&email).await?;
@@ -182,13 +182,13 @@ fn it_should_return_url_for_provider() {
 #[tokio::test]
 async fn it_should_refresh_token() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let session = api
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     let new_session = api.refresh_access_token(&session.refresh_token).await?;
@@ -201,13 +201,13 @@ async fn it_should_refresh_token() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_return_user() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let session = api
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     let user = api.get_user(&session.access_token).await?;
@@ -220,12 +220,12 @@ async fn it_should_return_user() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_update_user() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let api = get_api_client();
-    api.sign_up(EmailOrPhone::Email(email.clone()), &password)
+    api.sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
-    let session = api.sign_in(EmailOrPhone::Email(email), &password).await?;
+    let session = api.sign_in(EmailOrPhone::Email(email), password).await?;
 
     let new_email = get_random_email();
     let attributes = UserAttributes {
@@ -255,10 +255,10 @@ async fn it_should_invite_user_by_email() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_list_users() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
     let client_api = get_api_client();
     client_api
-        .sign_up(EmailOrPhone::Email(email), &password)
+        .sign_up(EmailOrPhone::Email(email), password)
         .await?;
 
     let api = get_service_api_client();
@@ -272,10 +272,10 @@ async fn it_should_list_users() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_get_user_by_id() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
     let client_api = get_api_client();
     let session = client_api
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     let api = get_service_api_client();

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 use std::error::Error;
 
 fn get_client() -> Client {
-    return Client::new("http://localhost:9998".to_string());
+    return Client::new("http://localhost:9998");
 }
 
 fn get_random_email() -> String {
@@ -21,11 +21,11 @@ fn get_random_email() -> String {
 #[tokio::test]
 async fn it_signs_up_with_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     let res = client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     assert_eq!(email, res.user.email);
@@ -36,14 +36,14 @@ async fn it_signs_up_with_email() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_throw_email_already_taken_error() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
-    let result = client.sign_up(EmailOrPhone::Email(email), &password).await;
+    let result = client.sign_up(EmailOrPhone::Email(email), password).await;
 
     match result {
         Ok(_) => panic!("Should throw error"),
@@ -56,14 +56,14 @@ async fn it_should_throw_email_already_taken_error() -> Result<(), Box<dyn Error
 #[tokio::test]
 async fn it_signs_in_with_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = client
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     assert_eq!(res.user.email, email);
@@ -74,16 +74,14 @@ async fn it_signs_in_with_email() -> Result<(), Box<dyn Error>> {
 async fn it_should_return_error_when_credentials_are_wrong_on_signin() -> Result<(), Box<dyn Error>>
 {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
-    client
-        .sign_up(EmailOrPhone::Email(email), &password)
-        .await?;
+    client.sign_up(EmailOrPhone::Email(email), password).await?;
 
     let wrong_email = get_random_email();
     let result = client
-        .sign_in(EmailOrPhone::Email(wrong_email), &password)
+        .sign_in(EmailOrPhone::Email(wrong_email), password)
         .await;
 
     match result {
@@ -110,14 +108,14 @@ async fn it_should_return_error_if_no_session_when_refreshing() -> Result<(), Bo
 #[tokio::test]
 async fn it_should_refresh_session() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let old_session = client
-        .sign_in(EmailOrPhone::Email(email.clone()), &password)
+        .sign_in(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     let session = client.refresh_session().await?;
@@ -131,11 +129,11 @@ async fn it_should_refresh_session() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_send_magic_link_with_valid_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = client.send_otp(EmailOrPhone::Email(email), None).await?;
 
@@ -160,15 +158,13 @@ async fn it_does_not_send_magic_link_with_invalid_email() -> Result<(), Box<dyn 
 #[tokio::test]
 async fn it_should_log_out() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
-    client
-        .sign_in(EmailOrPhone::Email(email), &password)
-        .await?;
+    client.sign_in(EmailOrPhone::Email(email), password).await?;
 
     let success = client.sign_out().await?;
 
@@ -192,11 +188,11 @@ async fn it_should_return_error_in_log_out_if_no_session() -> Result<(), Box<dyn
 #[tokio::test]
 async fn it_should_send_password_recovery_email() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
     let res = client.reset_password_for_email(&email).await?;
 
@@ -207,15 +203,13 @@ async fn it_should_send_password_recovery_email() -> Result<(), Box<dyn Error>> 
 #[tokio::test]
 async fn it_should_update_user() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
-    client
-        .sign_in(EmailOrPhone::Email(email), &password)
-        .await?;
+    client.sign_in(EmailOrPhone::Email(email), password).await?;
 
     let new_email = get_random_email();
     let attributes = UserAttributes {
@@ -234,11 +228,11 @@ async fn it_should_update_user() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn it_should_set_session_by_refresh_token() -> Result<(), Box<dyn Error>> {
     let email = get_random_email();
-    let password = String::from("Abcd1234!");
+    let password = "Abcd1234!";
 
     let mut client = get_client();
     let old_session = client
-        .sign_up(EmailOrPhone::Email(email.clone()), &password)
+        .sign_up(EmailOrPhone::Email(email.clone()), password)
         .await?;
 
     let session = client.set_session(&old_session.refresh_token).await?;


### PR DESCRIPTION
This change uses `impl Into<String>` or `impl AsRef<str>` for most attributes that previously used `String`, `&String` or `&str`.

The usage of the API should be more user-friendly this way, since it allows for a broader range of inputs without explicit conversion.