### PR TITLE
provider signin: first working proof of concept

### DIFF
--- a/examples/provider.rs
+++ b/examples/provider.rs
@@ -1,0 +1,20 @@
+use std::error::Error;
+
+use go_true::Api;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let url = "http://localhost:9999";
+
+    let mut client = Api::new(url);
+
+    let g_url = client.get_url_for_provider("google");
+
+    println!("Go here to sign in:\n{}", g_url);
+
+    let session = client.provider_sign_in().await.expect("Uhoh signin broke!");
+
+    println!("{:?}", session);
+
+    Ok(())
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -15,15 +15,16 @@ services:
       PORT: 9999
       GOTRUE_DISABLE_SIGNUP: "false"
       API_EXTERNAL_URL: http://localhost:9999
-      GOTRUE_SITE_URL: http://localhost:9999
+      GOTRUE_SITE_URL: http://localhost:6969
       GOTRUE_URI_ALLOW_LIST: https://supabase.io/docs
       GOTRUE_MAILER_AUTOCONFIRM: "false"
       GOTRUE_LOG_LEVEL: DEBUG
       GOTRUE_OPERATOR_TOKEN: super-secret-operator-token
       DATABASE_URL: "postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
-      GOTRUE_EXTERNAL_GOOGLE_ENABLED: "true"
-      GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: 53566906701-bmhc1ndue7hild39575gkpimhs06b7ds.apps.googleusercontent.com
-      GOTRUE_EXTERNAL_GOOGLE_SECRET: Sm3s8RE85rDcS36iMy8YjrpC
+      # Providers
+      GOTRUE_EXTERNAL_GOOGLE_ENABLED: ${GOTRUE_EXTERNAL_GOOGLE_ENABLED}
+      GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID}
+      GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOTRUE_EXTERNAL_GOOGLE_SECRET}
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: http://localhost:9999/callback
       GOTRUE_SMTP_HOST: mail
       GOTRUE_SMTP_PORT: 2500

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::HashMap,
+    io::{ErrorKind, Read, Write},
+    net::TcpListener,
+};
+
 use reqwest::header::{HeaderMap, HeaderValue, IntoHeaderName};
 use serde_json::json;
 
@@ -159,6 +165,98 @@ impl Api {
             .await?;
 
         return Ok(response);
+    }
+
+    /// Signs in with a provider
+    ///
+    /// Appropriate URI should be presented to the user before this function is called.
+    ///
+    /// # Example
+    ///
+    /// TODO
+    pub async fn provider_sign_in(&mut self) -> Result<Session, Box<dyn std::error::Error>> {
+        let listener = TcpListener::bind("127.0.0.1:6969").expect("Couldn't bind port 6969.");
+
+        let mut params = HashMap::new();
+
+        loop {
+            let (mut stream, _) = listener.accept().expect("Listener IO error");
+
+            // This javascript is mental, I have to make fetch happen because GoTrue puts the
+            // access token in the URI hash? Like is that intentional, surely should be on search
+            // params. This fix does require JS in browser but most oAuth sign in pages probably do too, so
+            // should be a non-issue.
+            let message = String::from(
+                "<script>fetch(`http://localhost:6969/token?${window.location.hash.replace('#','')})`)</script><h1>GoTrue-Rs</h1><h2>Signin sent to program.</h2><h3>You may close this tab.</h3>",
+            );
+
+            // TODO optional redirect to user provided URI
+
+            let res = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
+                message.len(),
+                message
+            );
+
+            loop {
+                match stream.write(res.as_bytes()) {
+                    Ok(_n) => break,
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+                    Err(e) => println!("Couldn't respond. {}", e),
+                }
+            }
+
+            let mut buf = [0; 4096];
+
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(_n) => break,
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
+            }
+
+            let raw = String::from_utf8(buf.to_vec()).unwrap();
+
+            let request_line = raw.lines().collect::<Vec<_>>()[0];
+
+            if !request_line.starts_with("GET /token?") {
+                // If this request isn't the one we sent with JS fetch, ignore it and wait for the
+                // right one.
+                continue;
+            }
+
+            let split_req = request_line
+                .strip_prefix("GET /token?")
+                .unwrap()
+                .split('&')
+                .collect::<Vec<&str>>();
+
+            for param in split_req {
+                let split_param = param.split('=').collect::<Vec<&str>>();
+                params.insert(split_param[0].to_owned(), split_param[1].to_owned());
+            }
+
+            if params.get("access_token").is_some() {
+                break;
+            }
+        }
+
+        let access_token = params.get("access_token").unwrap().clone();
+        let refresh_token = params.get("refresh_token").unwrap().clone();
+
+        let sesh = Session {
+            user: self.get_user(access_token.clone()).await?,
+            access_token,
+            refresh_token,
+            token_type: "JWT".into(),
+            expires_in: 3600, // TODO get correct time from params
+        };
+
+        Ok(sesh)
     }
 
     /// Sends an OTP Code and creates user if it does not exist


### PR DESCRIPTION
tested with google oauth locally and on supabase

runs a local `TcpListener` to be used as the endpoint after oAuth has gone through `/callback`

uses some _cursed_ inline javascript on the response to extract the access tokens from the URI hash, as we can't see that serverside

PR still needs tests, not sure how they'll work when we need a browser for oAuth flow?

also specific port setting seems to be required, but I think I've solved that problem before, will have a look through my old firebase auth code

let me know if this approach fits the goals of the project :)

closes issue #32 